### PR TITLE
fix an error message

### DIFF
--- a/src/ediv.c
+++ b/src/ediv.c
@@ -90,7 +90,7 @@ Obj FuncElementaryDivisorsPPartRkExpSmall(
   /* pr = p^(r+1) */
   probj = PowInt(pobj, SumInt(robj, INTOBJ_INT(1)));
   if (! IS_INTOBJ(probj)) { 
-     ErrorQuit("p^(r+2) must be a small integer",0L,0L);
+     ErrorQuit("p^(r+1) must be a small integer",0L,0L);
   }
   /* max number of summands of size p^(r+1)*p before reduction is necessary
      because of integer overflow */


### PR DESCRIPTION
Note that a few lines below, the same wrong (?) error message occurs, but in a context where it doesn't seem to make sense:
```C
  pr = (unsigned long) INT_INTOBJ(probj);
  chmax = ULONG_MAX/(pr) - 1;
  if (chmax == 0) {
     ErrorQuit("p^(r+2) must be a small int",0L,0L);
  }
```
However, I don't understand how that error could ever be triggered, given that `ULONG_MAX/INT_INTOBJ_MAX - 1` is 7.