### PR TITLE
Fix EDIM to work with current GAP master branch

### DIFF
--- a/src/ediv.c
+++ b/src/ediv.c
@@ -202,6 +202,7 @@ Obj FuncElementaryDivisorsPPartRkExpSmall(
   if (A1[0]==rk) { 
     RetypeBag(resobj, T_PLIST);
     i0 = res[0];
+    SET_LEN_PLIST(resobj, i0);
     for (i=1; i<=i0; i++) {
       SET_ELM_PLIST(resobj, i, INTOBJ_INT(res[i]));
     }


### PR DESCRIPTION
In the GAP master branch, the way we store the length of plists was changed.
The EDIM kernel module did not use the official API to set the length of a
plist it produced, which means it is broken with the current GAP master
branch.

This PR fixes this, while staying fully compatible with older GAP releases.

It would be *really* nice if a new EDIM release with this fix in it could be made ASAP; besides this fix, it then also would contain the test files added in February 2018 (!) in commit 3ba890e6d03db06d9997f33018b43ca298b901f1 -- if those had been in a released version of EDIM, we would have noticed the regression much sooner as part of our CI tests. As it is, the latest EDIM release 1.3.3 is not tested by us.