### PR TITLE
Use information from sysinfo.gap to locate gap and gac

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -2,9 +2,9 @@
 
 GAPPATH=@GAPPATH@
 
-GAP=$(GAPPATH)/bin/gap.sh
+GAP=@GAP@
 
-GAC=$(GAPPATH)/gac
+GAC=@GAC@
 
 .PHONY: clean doc test
 

--- a/configure
+++ b/configure
@@ -21,12 +21,19 @@ if [ -e "$GAPPATH/sysinfo.in" ]; then
   exit
 fi
 
+# set default values for GAP and GAC (may be overwritten by sysinfo.gap)
+GAP='$(GAPPATH)/bin/gap.sh'
+GAC='$(GAPPATH)/gac'
+
 # Reading variables from GAP build directory
 . "$GAPPATH/sysinfo.gap"
 
 echo "Using bin path: $GAParch"
 
 # Creating Makefile
-sed -e "s|@GAPPATH@|$GAPPATH|g" -e "s|@GAPARCH@|$GAParch|g" \
+sed -e "s|@GAPPATH@|$GAPPATH|g" \
+    -e "s|@GAPARCH@|$GAParch|g" \
+    -e "s|@GAP@|$GAP|g" \
+    -e "s|@GAC@|$GAC|g" \
              < Makefile.in > Makefile
 


### PR DESCRIPTION
... at least when it is available (requires GAP >= 4.12). If not, fall back to what was done before, and assume they are in a specific place in the GAPROOT.

The advantage of the new approach is that we basically only need to point the package build system at sysinfo.gap, and it will derive everything else it needs from that. This then makes it easy for e.g. Linux package distributions to package GAP in a way that is compatible with their various specifications and requirements as to where to place files.

The same could be done for Browse, but I am not aware of a git repository for that? (CC @ThomasBreuer)