### PR TITLE
Update list of PHONY targets, remove default target

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -6,9 +6,7 @@ GAP=$(GAPPATH)/bin/gap.sh
 
 GAC=$(GAPPATH)/gac
 
-.PHONY: clean doc test
-
-default: bin/@GAPARCH@/ediv.so 
+.PHONY: clean doc test distclean docclean
 
 bin/@GAPARCH@/ediv.so: src/ediv.c
 	@mkdir -p bin/@GAPARCH@


### PR DESCRIPTION
The dedicated `default` target seems pointless given that the first
target is default and the target for ediv.so is first anyway.
