### PR TITLE
Change 'make clean' to not remove Makefile

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -16,7 +16,7 @@ doc:
 	$(GAP)  makedocrel.g
 
 clean: 
-	rm -rf bin/@GAPARCH@ Makefile *~
+	rm -rf bin/@GAPARCH@ *~
 
 distclean:
 	rm -rf bin Makefile Makefile-*

--- a/Makefile.in.old
+++ b/Makefile.in.old
@@ -24,7 +24,7 @@ doc:
 	($(GAP)  makedocrel.g)
 
 clean: 
-	rm -rf bin/@GAPARCH@ Makefile Makefile-$(CONFIGNAME) *~
+	rm -rf bin/@GAPARCH@ *~
 
 distclean:
 	rm -rf bin Makefile Makefile-*


### PR DESCRIPTION
This way, EDIM matches the behavior of all other GAP packages with a
Makefile, with the exception of Browse.

This also matches how `make clean` works for Makefiles produced by GNU
automake and by cmake and virtually any make based build system I am
familiar with. The GNU Coding Standards also prescribe this behavior and
they are arguably as close as a "standard" for this as we have. Indeed,
to quote from
<https://www.gnu.org/prep/standards/standards.html#Standard-Targets-for-Users>:

> Delete all files in the current directory that are normally created by
> building the program. Also delete files in other directories if they
> are created by this makefile. However, don’t delete the files that
> record the configuration. Also preserve files that could be made by
> building, but normally aren’t because the distribution comes with
> them. There is no need to delete parent directories that were created
> with ‘mkdir -p’, since they could have existed anyway.

This is different from the `distclean` target which also would delete
`Makefile` (and this target already exists in EDIM, of course).
