### PR TITLE
Also use IsKernelExtensionAvailable in PackageInfo.g

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -57,8 +57,7 @@ Dependencies := rec(
 ),
 
 AvailabilityTest := function()
-  if not "ediv" in SHOW_STAT() and 
-     Filename(DirectoriesPackagePrograms("edim"), "ediv.so") = fail then
+  if not IsKernelExtensionAvailable("EDIM","ediv") then
     LogPackageLoadingMessage( PACKAGE_WARNING,
               [ "The EDIM kernel function 'ElementaryDivisorsPPartRkExpSmall'",
                 "is not available.",


### PR DESCRIPTION
In 98ea627b58c7502fd3cab6b792bd98590f6be223 you started to use `IsKernelExtensionAvailable`. Then you could also use it in `AvailabilityTest` in `PackageInfo.g`.

However, this function requires GAP >= 4.12. So perhaps you'd like to revert that commit -- or else, if you prefer to keep using this new helper, then there isn't much of a point to keep `Makefile.in.old` and `configure.old`, and `PackageInfo.g` should be changed to indicate that GAP 4.12 is now required.