### PR TITLE
Makefile.in: pass user CPPFLAGS, CFLAGS, and LDFLAGS to gac

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -8,7 +8,7 @@ include $(GAPPATH)/sysinfo.gap
 
 bin/$(GAParch)/ediv.so: src/ediv.c Makefile
 	@mkdir -p bin/$(GAParch)
-	$(GAC) -d -o bin/$(GAParch)/ediv.so src/ediv.c
+	$(GAC) -d -p "$(CPPFLAGS)" -p "$(CFLAGS)" -P "$(LDFLAGS)" -o bin/$(GAParch)/ediv.so src/ediv.c
 
 doc:
 	$(GAP)  makedocrel.g


### PR DESCRIPTION
As discussed in https://github.com/gap-system/gap/issues/5601, these should be passed to gac by each package.